### PR TITLE
Treeshaking / Reduced image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,11 +32,6 @@ RUN         dpkg --add-architecture i386 \
             && wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
             && wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources \
             && apt-get update \
-            # Install rcon
-            && cd /tmp/ \
-            && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
-            && tar xvf rcon.tar.gz \
-            && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/ \
             # Install wine and with recommends
             && apt install --install-recommends winehq-stable -y \
             # Set up Winetricks

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,6 @@ RUN         dpkg --add-architecture i386 \
             && apt-get update \
             # Install wine and with recommends
             && apt install --install-recommends winehq-stable -y \
-            # Set up Winetricks
-            && wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
-            && chmod +x /usr/sbin/winetricks \
             # Deep Clean: Remove man pages, docs, and apt cache
             && rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/* \
             && apt clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,69 +1,6 @@
-FROM       debian:trixie-slim
+FROM        debian:trixie-slim
 
 ENV         DEBIAN_FRONTEND=noninteractive
-
-## Update base packages
-RUN          apt-get update \
-	&& apt-get upgrade -y \
-	&& rm -rf /var/lib/apt/lists/*
-
-## Install dependencies
-RUN          apt-get update && apt-get install -y --no-install-recommends \
-	binutils \
-	ca-certificates \
-	cabextract \
-	curl \
-	ffmpeg \
-	g++ \
-	gcc \
-	gdb \
-	git \
-	gnupg \
-	icu-devtools \
-	iproute2 \
-	libatomic1 \
-	libc++-dev \
-	libc6 \
-	libduktape207 \
-	libevent-dev \
-	libfluidsynth3 \
-	libfontconfig1 \
-	libgcc-13-dev \
-	liblua5.3-0 \
-	liblzo2-2 \
-	libmariadb-dev-compat \
-	libprotobuf32t64 \
-	libsdl1.2debian \
-	libsdl2-2.0-0 \
-	libsqlite3-dev \
-	libssl-dev \
-	libstdc++6 \
-	libunwind8 \
-	libz3-dev \
-	libzadc4 \
-	libzip5 \
-	locales \
-	net-tools \
-	netcat-traditional \
-	procps \
-	rapidjson-dev \
-	sqlite3 \
-	tar \
-	telnet \
-	tini \
-	tzdata \
-	unzip \
-	wget \
-	xz-utils \
-	zip \
-	&& rm -rf /var/lib/apt/lists/*
-
-
-# Generate locale
-RUN          sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
-	&& locale-gen \
-	&& update-locale LANG=en_US.UTF-8
-
 
 ENV         USER=container
 ENV         HOME=/home/container
@@ -71,38 +8,92 @@ WORKDIR		/home/container
 
 STOPSIGNAL	SIGINT
 
-## install required packages
-RUN             dpkg --add-architecture i386 \
-                && apt update -y \
-                && apt install -y --no-install-recommends gnupg2 numactl tzdata libntlm0 winbind xvfb xauth python3 libncurses6 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+## Update base packages
+RUN         apt-get update \
+	        && apt-get upgrade -y \
+	        && rm -rf /var/lib/apt/lists/* \
+            && apt-get update && apt-get install -y --no-install-recommends \
+            binutils \
+            ca-certificates \
+            cabextract \
+            curl \
+            ffmpeg \
+            g++ \
+            gcc \
+            gdb \
+            git \
+            gnupg \
+            icu-devtools \
+            iproute2 \
+            libatomic1 \
+            libc++-dev \
+            libc6 \
+            libduktape207 \
+            libevent-dev \
+            libfluidsynth3 \
+            libfontconfig1 \
+            libgcc-13-dev \
+            liblua5.3-0 \
+            liblzo2-2 \
+            libmariadb-dev-compat \
+            libprotobuf32t64 \
+            libsdl1.2debian \
+            libsdl2-2.0-0 \
+            libsqlite3-dev \
+            libssl-dev \
+            libstdc++6 \
+            libunwind8 \
+            libz3-dev \
+            libzadc4 \
+            libzip5 \
+            locales \
+            net-tools \
+            netcat-traditional \
+            procps \
+            rapidjson-dev \
+            sqlite3 \
+            tar \
+            telnet \
+            tini \
+            tzdata \
+            unzip \
+            wget \
+            xz-utils \
+            zip \
+            && rm -rf /var/lib/apt/lists/* \
+            # Generate locale
+            && sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+            && locale-gen \
+            && update-locale LANG=en_US.UTF-8 \
+            # install required packages
+            && dpkg --add-architecture i386 \
+            && apt update -y \
+            && apt install -y --no-install-recommends gnupg2 numactl tzdata libntlm0 winbind xvfb xauth python3 libncurses6 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386 \
+            && cd /tmp/ \
+            && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
+            && tar xvf rcon.tar.gz \
+            && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/ \
+            # Install wine and with recommends
+            && mkdir -pm755 /etc/apt/keyrings \
+            && wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key \
+            && wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources \
+            && apt update \
+            && apt install --install-recommends winehq-stable cabextract -y \
+            # Set up Winetricks
+            && wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
+            && chmod +x /usr/sbin/winetricks
 
-RUN             cd /tmp/ \
-                && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
-                && tar xvf rcon.tar.gz \
-                && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
+ENV         HOME=/home/container
+ENV         WINEPREFIX=/home/container/.wine
+ENV         WINEDLLOVERRIDES="mscoree,mshtml="
+ENV         DISPLAY=:0
+ENV         DISPLAY_WIDTH=1024
+ENV         DISPLAY_HEIGHT=768
+ENV         DISPLAY_DEPTH=16
+ENV         AUTO_UPDATE=1
+ENV         XVFB=1
 
-# Install wine and with recommends
-RUN             mkdir -pm755 /etc/apt/keyrings
-RUN             wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-RUN             wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources
-RUN             apt update
-RUN             apt install --install-recommends winehq-stable cabextract -y
-
-# Set up Winetricks
-RUN	            wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
-                && chmod +x /usr/sbin/winetricks
-
-ENV             HOME=/home/container
-ENV             WINEPREFIX=/home/container/.wine
-ENV             WINEDLLOVERRIDES="mscoree,mshtml="
-ENV             DISPLAY=:0
-ENV             DISPLAY_WIDTH=1024
-ENV             DISPLAY_HEIGHT=768
-ENV             DISPLAY_DEPTH=16
-ENV             AUTO_UPDATE=1
-ENV             XVFB=1
-
-LABEL author="struppi" maintainer="https://github.com/struppinet"
+LABEL       author="struppi" maintainer="https://github.com/struppinet"
 
 # customization
 VOLUME ["/home/container/server_files"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN         dpkg --add-architecture i386 \
                locales \
                tar \
                wget \
+               nano \
                # Install required packages for wine
                winbind \
                xvfb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN         dpkg --add-architecture i386 \
             # Install additional packages
 	        && apt-get install -y --no-install-recommends \
             ca-certificates \
-            cabextract \
             curl \
             locales \
             tar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,106 @@
-FROM ghcr.io/ptero-eggs/yolks:wine_latest
+FROM       debian:trixie-slim
+
+ENV         DEBIAN_FRONTEND=noninteractive
+
+## Update base packages
+RUN          apt-get update \
+	&& apt-get upgrade -y \
+	&& rm -rf /var/lib/apt/lists/*
+
+## Install dependencies
+RUN          apt-get update && apt-get install -y --no-install-recommends \
+	binutils \
+	ca-certificates \
+	cabextract \
+	curl \
+	ffmpeg \
+	g++ \
+	gcc \
+	gdb \
+	git \
+	gnupg \
+	icu-devtools \
+	iproute2 \
+	libatomic1 \
+	libc++-dev \
+	libc6 \
+	libduktape207 \
+	libevent-dev \
+	libfluidsynth3 \
+	libfontconfig1 \
+	libgcc-13-dev \
+	liblua5.3-0 \
+	liblzo2-2 \
+	libmariadb-dev-compat \
+	libprotobuf32t64 \
+	libsdl1.2debian \
+	libsdl2-2.0-0 \
+	libsqlite3-dev \
+	libssl-dev \
+	libstdc++6 \
+	libunwind8 \
+	libz3-dev \
+	libzadc4 \
+	libzip5 \
+	locales \
+	net-tools \
+	netcat-traditional \
+	procps \
+	rapidjson-dev \
+	sqlite3 \
+	tar \
+	telnet \
+	tini \
+	tzdata \
+	unzip \
+	wget \
+	xz-utils \
+	zip \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+# Generate locale
+RUN          sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+	&& locale-gen \
+	&& update-locale LANG=en_US.UTF-8
+
+
+ENV         USER=container
+ENV         HOME=/home/container
+WORKDIR		/home/container
+
+STOPSIGNAL	SIGINT
+
+## install required packages
+RUN             dpkg --add-architecture i386 \
+                && apt update -y \
+                && apt install -y --no-install-recommends gnupg2 numactl tzdata libntlm0 winbind xvfb xauth python3 libncurses6 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386
+
+RUN             cd /tmp/ \
+                && curl -sSL https://github.com/gorcon/rcon-cli/releases/download/v0.10.3/rcon-0.10.3-amd64_linux.tar.gz > rcon.tar.gz \
+                && tar xvf rcon.tar.gz \
+                && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/
+
+# Install wine and with recommends
+RUN             mkdir -pm755 /etc/apt/keyrings
+RUN             wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+RUN             wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources
+RUN             apt update
+RUN             apt install --install-recommends winehq-stable cabextract -y
+
+# Set up Winetricks
+RUN	            wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
+                && chmod +x /usr/sbin/winetricks
+
+ENV             HOME=/home/container
+ENV             WINEPREFIX=/home/container/.wine
+ENV             WINEDLLOVERRIDES="mscoree,mshtml="
+ENV             DISPLAY=:0
+ENV             DISPLAY_WIDTH=1024
+ENV             DISPLAY_HEIGHT=768
+ENV             DISPLAY_DEPTH=16
+ENV             AUTO_UPDATE=1
+ENV             XVFB=1
 
 LABEL author="struppi" maintainer="https://github.com/struppinet"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN         dpkg --add-architecture i386 \
                # Install required packages for wine
                winbind \
                xvfb \
+               xauth \
             # Generate locale
             && sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
             && locale-gen \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,14 @@ RUN         dpkg --add-architecture i386 \
 	        && apt-get upgrade -y \
             # Install additional packages
 	        && apt-get install -y --no-install-recommends \
-            ca-certificates \
-            curl \
-            locales \
-            tar \
-            wget \
-            # Install required packages for wine
-            winbind \
-            xvfb \
+               ca-certificates \
+               curl \
+               locales \
+               tar \
+               wget \
+               # Install required packages for wine
+               winbind \
+               xvfb \
             # Generate locale
             && sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
             && locale-gen \
@@ -32,7 +32,8 @@ RUN         dpkg --add-architecture i386 \
             && wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/trixie/winehq-trixie.sources \
             && apt-get update \
             # Install wine and with recommends
-            && apt install --install-recommends winehq-stable -y \
+            && apt install -y --no-install-recommends \
+               winehq-stable \
             # Deep Clean: Remove man pages, docs, and apt cache
             && rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/* \
             && apt clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,55 +14,15 @@ RUN         dpkg --add-architecture i386 \
 	        && apt-get upgrade -y \
             # Install additional packages
 	        && apt-get install -y --no-install-recommends \
-            binutils \
             ca-certificates \
             cabextract \
             curl \
-            ffmpeg \
-            g++ \
-            gcc \
-            gdb \
-            git \
-            gnupg \
-            icu-devtools \
-            iproute2 \
-            libatomic1 \
-            libc++-dev \
-            libc6 \
-            libduktape207 \
-            libevent-dev \
-            libfluidsynth3 \
-            libfontconfig1 \
-            libgcc-13-dev \
-            liblua5.3-0 \
-            liblzo2-2 \
-            libmariadb-dev-compat \
-            libprotobuf32t64 \
-            libsdl1.2debian \
-            libsdl2-2.0-0 \
-            libsqlite3-dev \
-            libssl-dev \
-            libstdc++6 \
-            libunwind8 \
-            libz3-dev \
-            libzadc4 \
-            libzip5 \
             locales \
-            net-tools \
-            netcat-traditional \
-            procps \
-            rapidjson-dev \
-            sqlite3 \
             tar \
-            telnet \
-            tini \
-            tzdata \
-            unzip \
             wget \
-            xz-utils \
-            zip \
             # Install required packages for wine
-            gnupg2 numactl tzdata libntlm0 winbind xvfb xauth python3 libncurses6 libncurses6:i386 libsdl2-2.0-0 libsdl2-2.0-0:i386 \
+            winbind \
+            xvfb \
             # Generate locale
             && sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
             && locale-gen \
@@ -78,7 +38,7 @@ RUN         dpkg --add-architecture i386 \
             && tar xvf rcon.tar.gz \
             && mv rcon-0.10.3-amd64_linux/rcon /usr/local/bin/ \
             # Install wine and with recommends
-            && apt install --install-recommends winehq-stable cabextract -y \
+            && apt install --install-recommends winehq-stable -y \
             # Set up Winetricks
             && wget -q -O /usr/sbin/winetricks https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks \
             && chmod +x /usr/sbin/winetricks \


### PR DESCRIPTION
I took a closer look at what this is builing on and I noticed a few issues.
* A lot of things get installed that are unnecessary for our Aska server.
* Due to building upon two base images (aska->wine->debian) the resulting docker layers are inefficient.

Both things bloat the resulting docker image quite heavily.

I condensed everything into one Dockerfile now and removed the unnecessary stuff.
This reduces the image size from ~4.62GB (1.08 GB compressed) to ~3.24GB (748.72 MB compressed). Thats around 30% reduction.

The only downside is that the build process takes longer but is still reasonable (~3min).